### PR TITLE
Register alias/facade

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -3,6 +3,7 @@
 use App;
 use Event;
 use System\Classes\PluginBase;
+use Illuminate\Foundation\AliasLoader;
 
 /**
  * Debugbar Plugin Information File
@@ -32,6 +33,10 @@ class Plugin extends PluginBase
     {
         // Service provider
         App::register('\Barryvdh\Debugbar\ServiceProvider');
+
+        // Register alias
+        $alias = AliasLoader::getInstance();
+        $alias->alias('Debugbar', '\Barryvdh\Debugbar\Facade');
 
         // Twig extensions
         Event::listen('cms.page.beforeDisplay', function($controller, $url, $page) {


### PR DESCRIPTION
That allows adding debug messages and stopwatches programmatically.

Copied from the laravel-debugbar docs:

You can now add messages using the Facade (when added), using the PSR-3 levels (debug, info, notice, warning, error, critical, alert, emergency):

``` php
Debugbar::info($object);
Debugbar::error('Error!');
Debugbar::warning('Watch out…');
Debugbar::addMessage('Another message', 'mylabel');
```

And start/stop timing:

``` php
Debugbar::startMeasure('render','Time for rendering');
Debugbar::stopMeasure('render');
Debugbar::addMeasure('now', LARAVEL_START, microtime(true));
Debugbar::measure('My long operation', function() {
    // Do something…
});
```

Or log exceptions:

``` php
try {
    throw new Exception('foobar');
} catch (Exception $e) {
    Debugbar::addException($e);
}
```
