### PR TITLE
Exceptions during ajax requests are returned to the active debugbar.

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -38,6 +38,11 @@ class Plugin extends PluginBase
         $alias = AliasLoader::getInstance();
         $alias->alias('Debugbar', '\Barryvdh\Debugbar\Facade');
 
+        // Register middleware
+        if (Config::get('app.debugAjax', false)) {
+            $this->app['Illuminate\Contracts\Http\Kernel']->pushMiddleware('\Bedard\Debugbar\Middleware\Debugbar');
+        }
+
         // Twig extensions
         Event::listen('cms.page.beforeDisplay', function($controller, $url, $page) {
             $twig = $controller->getTwig();

--- a/middleware/debugbar.php
+++ b/middleware/debugbar.php
@@ -1,0 +1,57 @@
+<?php namespace Bedard\Debugbar\Middleware;
+
+use Closure;
+use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Routing\Middleware;
+use Illuminate\Http\Response;
+use October\Rain\Exception\AjaxException;
+
+class Debugbar implements Middleware
+{
+
+    /**
+     * The Laravel Application
+     *
+     * @var Application
+     */
+    protected $app;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  Application $app
+     * @return void
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        /** @var \Barryvdh\Debugbar\LaravelDebugbar $debugbar */
+        $debugbar = $this->app['debugbar'];
+        try {
+            /** @var \Illuminate\Http\Response $response */
+            $response = $next($request);
+            return $debugbar->modifyResponse($request, $response);
+        } catch (\Exception $ex) {
+            if (!\Request::ajax()) {
+                throw $ex;
+            }
+            $debugbar->addException($ex);
+            $message = $ex instanceof AjaxException
+                ? $ex->getContents() : \October\Rain\Exception\ErrorHandler::getDetailedMessage($ex);
+
+            return \Response::make($message, 500, $debugbar->getDataAsHeaders());
+        }
+
+    }
+}


### PR DESCRIPTION
Add `'debugAjax' => true` to `config/app.php` to enable this feature.
