### PR TITLE
Fix a fatal error when cms.page.beforeDisplay is fired multiple times

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -60,8 +60,10 @@ class Plugin extends PluginBase
 
             // Twig extensions
             $twig = $controller->getTwig();
-            $twig->addExtension(new \Barryvdh\Debugbar\Twig\Extension\Debug($this->app));
-            $twig->addExtension(new \Barryvdh\Debugbar\Twig\Extension\Stopwatch($this->app));
+            if(!$twig->hasExtension(\Barryvdh\Debugbar\Twig\Extension\Debug::class)){
+                $twig->addExtension(new \Barryvdh\Debugbar\Twig\Extension\Debug($this->app));
+                $twig->addExtension(new \Barryvdh\Debugbar\Twig\Extension\Stopwatch($this->app));
+            }
         });
     }
 }


### PR DESCRIPTION
In a special use case of embedding other pages into current page, I had to call a custom implementation of `run()` method similar to `run()` method of `Cms\Classes\Controller` class, through a plugin and in that case  `cms.page.beforeDisplay` event fires multiple times.

As a result, I got un-handled Exception from Twig with message **Unable to register extension "Laravel_Debugbar_Debug" as extensions have already been initialized.**. To fix this, I had to wrap the `$twig->addExtension()` calls with the if condition as in this PR.

I believe, this change is a safe & backward compatible change and gets merged ASAP.