### PR TITLE
Add support for displaying the debugbar to logged out users

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -58,7 +58,7 @@ class Plugin extends PluginBase
         Event::listen('cms.page.beforeDisplay', function($controller, $url, $page)
         {
             // Only show for authenticated backend users
-            if (!BackendAuth::check()) {
+            if (!BackendAuth::check() && !\Config::get('app.debugLoggedOut', false)) {
                 Debugbar::disable();
             }
 

--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ Easily see what's going on under the hood of your October application.
 
 If you installed the plugin via October's plugin marketplace, just set ```debug``` to ```true``` in ```config/app.php```, and the debugbar should appear in your backend. If the plugin was installed without using the marketplace, you'll need to also run a ```composer update``` from ```/plugins/bedard/debugbar```. See [barryvdh/laravel-debugbar](https://github.com/barryvdh/laravel-debugbar) for more usage instructions and documentation. 
 
+To show the debugbar for logged out frontend users set ```debugLoggedOut``` to ```true``` in ```config/app.php```.
+
 To include exceptions in the response header of ajax calls set ```debugAjax``` to ```true``` in ```config/app.php```.


### PR DESCRIPTION
This is useful when displaying different content to logged in and logged out users. 

For example community comment moderators (logged in to the frontend but not the backend) may see pending, deleted, spam and private comments where all these are invisible to logged out users. 

Allowing debugbar for logged out users during development aids in checking the different SQL queries between the two groups.