### PR TITLE
Add a new collector for October models

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -49,6 +49,10 @@ class Plugin extends PluginBase
         $alias = AliasLoader::getInstance();
         $alias->alias('Debugbar', \Barryvdh\Debugbar\Facade::class);
 
+        $debugBar = $this->app->make('Barryvdh\Debugbar\LaravelDebugbar');
+        $modelsCollector = $this->app->make('RainLab\Debugbar\DataCollectors\OctoberModelsCollector');
+        $debugBar->addCollector($modelsCollector);
+
         // Register middleware
         if (Config::get('app.debugAjax', false)) {
             $this->app[HttpKernelContract::class]->pushMiddleware(\RainLab\Debugbar\Middleware\InterpretsAjaxExceptions::class);

--- a/datacollectors/OctoberModelsCollector.php
+++ b/datacollectors/OctoberModelsCollector.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace RainLab\Debugbar\DataCollectors;
+
+use October\Rain\Database\Model;
+use Illuminate\Contracts\Events\Dispatcher;
+use Barryvdh\Debugbar\DataCollector\ModelsCollector;
+
+class OctoberModelsCollector extends ModelsCollector
+{
+    public $models = [];
+    public $count = 0;
+
+    /**
+     * @param Dispatcher $events
+     */
+    public function __construct(Dispatcher $events)
+    {
+        Model::extend(function ($model) {
+            $model->bindEvent('model.afterFetch', function () use ($model) {
+                $class = get_class($model);
+                $this->models[$class] = ($this->models[$class] ?? 0) + 1;
+                $this->count++;
+            });
+        });
+    }
+}


### PR DESCRIPTION
Hi guys,

I see that in the `October\Rain\Database\Model` the `retrieved` event is not fired like in the Eloquent one and this is the one that the original debug bar is listening for. I guess it's for some reason so I've decided to add a new collector to the debugbar which will bind to `afterFetch` event.

Suggestions welcomed but it works nicely :)

Have a good day,

Tomasz Strojny