### PR TITLE
Add backend/cms routes

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -79,7 +79,7 @@ class Plugin extends PluginBase
             $debugBar->addCollector(new OctoberBackendCollector($controller, $action, $params));
         });
 
-        Event::listen('cms.page.display', function(CmsController $controller, $url, Page $page) use ($debugBar) {
+        Event::listen('cms.page.beforeDisplay', function(CmsController $controller, $url, Page $page) use ($debugBar) {
             $debugBar->addCollector(new OctoberCmsCollector($controller, $url, $page));
         });
     }

--- a/Plugin.php
+++ b/Plugin.php
@@ -1,9 +1,15 @@
 <?php namespace RainLab\Debugbar;
 
 use App;
+use Backend\Classes\Controller as BackendController;
+use Cms\Classes\Controller as CmsController;
+use Cms\Classes\Page;
 use Event;
 use Config;
 use Backend\Models\UserRole;
+use Illuminate\Routing\Events\RouteMatched;
+use RainLab\Debugbar\DataCollectors\OctoberBackendCollector;
+use RainLab\Debugbar\DataCollectors\OctoberCmsCollector;
 use System\Classes\PluginBase;
 use System\Classes\CombineAssets;
 use Illuminate\Foundation\AliasLoader;
@@ -49,9 +55,6 @@ class Plugin extends PluginBase
         $alias = AliasLoader::getInstance();
         $alias->alias('Debugbar', \Barryvdh\Debugbar\Facade::class);
 
-        $debugBar = $this->app->make('Barryvdh\Debugbar\LaravelDebugbar');
-        $modelsCollector = $this->app->make('RainLab\Debugbar\DataCollectors\OctoberModelsCollector');
-        $debugBar->addCollector($modelsCollector);
 
         // Register middleware
         if (Config::get('app.debugAjax', false)) {
@@ -61,8 +64,25 @@ class Plugin extends PluginBase
         $this->registerResourceInjection();
 
         $this->registerTwigExtensions();
+
+        $this->addCollectors();
     }
 
+    public function addCollectors()
+    {
+        /** @var \Barryvdh\Debugbar\LaravelDebugbar $debugBar */
+        $debugBar = $this->app->make('Barryvdh\Debugbar\LaravelDebugbar');
+        $modelsCollector = $this->app->make('RainLab\Debugbar\DataCollectors\OctoberModelsCollector');
+        $debugBar->addCollector($modelsCollector);
+
+        Event::listen('backend.page.beforeDisplay', function (BackendController $controller, $action, array $params) use ($debugBar) {
+            $debugBar->addCollector(new OctoberBackendCollector($controller, $action, $params));
+        });
+
+        Event::listen('cms.page.display', function(CmsController $controller, $url, Page $page) use ($debugBar) {
+            $debugBar->addCollector(new OctoberCmsCollector($controller, $url, $page));
+        });
+    }
     /**
      * register the service provider
      */

--- a/datacollectors/OctoberBackendCollector.php
+++ b/datacollectors/OctoberBackendCollector.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace RainLab\Debugbar\DataCollectors;
+
+use Backend\Classes\Controller;
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\Renderable;
+
+class OctoberBackendCollector extends DataCollector implements Renderable
+{
+    /** @var Controller  */
+    protected $controller;
+    /** @var string */
+    protected $action;
+    /** @var array  */
+    protected $params;
+
+    public function __construct(Controller $controller, $action, array $params)
+    {
+        $this->controller = $controller;
+        $this->action = $action;
+        $this->params = $params;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function collect()
+    {
+        $result = [
+            'controller' => get_class($this->controller),
+            'action' => $this->action,
+            'params' => $this->params,
+        ];
+
+        if (class_exists(get_class($this->controller)) && method_exists($this->controller, $this->action)) {
+            $reflector = new \ReflectionMethod($this->controller, $this->action);
+
+            $filename = ltrim(str_replace(base_path(), '', $reflector->getFileName()), '/');
+            $result['file'] = $filename . ':' . $reflector->getStartLine() . '-' . $reflector->getEndLine();
+        }
+
+        return $result;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'backend';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getWidgets()
+    {
+        return [
+            "backend" => [
+                "icon" => "share",
+                "widget" => "PhpDebugBar.Widgets.VariableListWidget",
+                "map" => "backend",
+                "default" => "{}"
+            ]
+        ];
+    }
+}

--- a/datacollectors/OctoberCmsCollector.php
+++ b/datacollectors/OctoberCmsCollector.php
@@ -55,7 +55,7 @@ class OctoberCmsCollector extends DataCollector implements Renderable
     public function getWidgets()
     {
         return [
-            "cms" => [
+            "route" => [
                 "icon" => "share",
                 "widget" => "PhpDebugBar.Widgets.VariableListWidget",
                 "map" => "cms",

--- a/datacollectors/OctoberCmsCollector.php
+++ b/datacollectors/OctoberCmsCollector.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace RainLab\Debugbar\DataCollectors;
+
+use Cms\Classes\Controller;
+use Cms\Classes\Page;
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\Renderable;
+
+class OctoberCmsCollector extends DataCollector implements Renderable
+{
+    /** @var Controller  */
+    protected $controller;
+    /** @var string */
+    protected $url;
+    /** @var array  */
+    protected $page;
+
+    public function __construct(Controller $controller, $url, Page $page)
+    {
+        $this->controller = $controller;
+        $this->url = $url;
+        $this->page = $page;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function collect()
+    {
+        $result = [
+            'controller' => get_class($this->controller),
+            'url' => $this->url,
+        ];
+
+        foreach ($this->page->toArray() as $key => $value) {
+            $result[$key] = is_scalar($value) ? $value : $this->formatVar($value);
+        }
+
+        return $result;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'cms';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getWidgets()
+    {
+        return [
+            "cms" => [
+                "icon" => "share",
+                "widget" => "PhpDebugBar.Widgets.VariableListWidget",
+                "map" => "cms",
+                "default" => "{}"
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
This adds two new collectors: Backend and CMS, depending on which event is fired:

![image](https://user-images.githubusercontent.com/973269/145708618-3eda525b-312d-44fe-9e4e-31169b5f3f7c.png)

![image](https://user-images.githubusercontent.com/973269/145708623-5cf60011-0943-417b-8f80-963d44b6002b.png)

Related: #48 