### PR TITLE
Disable events by default

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -167,7 +167,7 @@ return [
         'symfony_request' => true,  // Only one can be enabled..
         'mail'            => true,  // Catch mail messages
         'laravel'         => false, // Laravel version and environment
-        'events'          => true, // All events fired
+        'events'          => false, // All events fired
         'default_request' => false, // Regular or special Symfony request logger
         'logs'            => false, // Add the latest log messages
         'files'           => false, // Show the included files


### PR DESCRIPTION
Can really slow the front-end down when it has many events, perhaps better to disable by default.