### PR TITLE
ObjectCountCollector instead of Barryvdh\Debugbar\DataCollector\ModelsCollector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "keywords": ["october", "debugbar"],
     "require": {
-        "barryvdh/laravel-debugbar": "~3.0"
+        "barryvdh/laravel-debugbar": "~3.10.3"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "keywords": ["october", "debugbar"],
     "require": {
-        "barryvdh/laravel-debugbar": "~3.10.3"
+        "barryvdh/laravel-debugbar": "^3.10.3"
     },
     "extra": {
         "laravel": {

--- a/datacollectors/OctoberModelsCollector.php
+++ b/datacollectors/OctoberModelsCollector.php
@@ -3,24 +3,17 @@
 namespace RainLab\Debugbar\DataCollectors;
 
 use October\Rain\Database\Model;
-use Illuminate\Contracts\Events\Dispatcher;
-use Barryvdh\Debugbar\DataCollector\ModelsCollector;
+use DebugBar\DataCollector\ObjectCountCollector;
 
-class OctoberModelsCollector extends ModelsCollector
+class OctoberModelsCollector extends ObjectCountCollector
 {
-    public $models = [];
-    public $count = 0;
-
-    /**
-     * @param Dispatcher $events
-     */
-    public function __construct(Dispatcher $events)
+    public function __construct()
     {
+        parent::__construct('models');
+
         Model::extend(function ($model) {
             $model->bindEvent('model.afterFetch', function () use ($model) {
-                $class = get_class($model);
-                $this->models[$class] = ($this->models[$class] ?? 0) + 1;
-                $this->count++;
+                $this->countClass($model);
             });
         });
     }


### PR DESCRIPTION
`Barryvdh\Debugbar\DataCollector\ModelsCollector` will be removed in the future (https://github.com/barryvdh/laravel-debugbar/pull/1517)

They upstream to `DebugBar\DataCollector\ObjectCountCollector` 
[barryvdh/laravel-debugbar/src/LaravelDebugbar.php#L427-L432](https://github.com/barryvdh/laravel-debugbar/blob/d1a48965f2b25a6cec2eea07d719b568a37c9a88/src/LaravelDebugbar.php#L427-L432)
[maximebf/php-debugbar/src/DebugBar/DataCollector/ObjectCountCollector.php](https://github.com/maximebf/php-debugbar/blob/master/src/DebugBar/DataCollector/ObjectCountCollector.php)

Closes #59