### PR TITLE
changed $widget from array to object

### DIFF
--- a/datacollectors/OctoberBackendCollector.php
+++ b/datacollectors/OctoberBackendCollector.php
@@ -90,7 +90,7 @@ class OctoberBackendCollector extends DataCollector implements Renderable
                     $reflector = new \ReflectionMethod($this->controller, $handler);
                 }
 
-                foreach ((array) $this->controller->widget as $widget) {
+                foreach ($this->controller->widget as $widget) {
                     if (method_exists($widget, $handler)) {
                         $reflector = new \ReflectionMethod($widget, $handler);
                     }


### PR DESCRIPTION
f.e. querying /system/updates and pasting an image in richeditor field resulted as error: Argument #1 ($object_or_class) must be of type object|string, array given" 

Tested in V4:
October 4.1.3 
debugbar-plugin 3.3.8

Tested in V3:
October 3.7.12
debugbar-plugin 3.3.8